### PR TITLE
Update README.md code block for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,23 +11,23 @@ class BaseElement extends HTMLElement {
 	 */
 	props: Properties;
 	/**
-	 * it is resolved once the component has been mounted the document
+	 * resolves once the component has been mounted to the document
 	 */
 	mounted: Promise<void>;
 	/**
-	 * It is solved once the component has been unmounted the document.
+	 * resolves once the component has been unmounted from the document.
 	 */
 	unmounted: Promise<void>;
 	/**
-	 * defines the observables as property and attribute of the component
+	 * defines the observables as properties and attributes of the component
 	 */
 	static observables: Observables;
 	/**
-	 * validate to `value`, and then deliver it to the` update({[name]:value})` method.
+	 * validates the `value` which is then delivered to the` update({[name]:value})` method.
 	 */
 	setProperty(name: string, value: Values): void;
 	/**
-	 * is dispatched every time `setProperty` is executed
+	 * dispatches every time `setProperty` is successfully executed
 	 */
 	update(props: Properties): void;
 }


### PR DESCRIPTION
Here are a few small changes that keep the documentation consistent with itself. This project looks amazing, and these changes helped me follow what it does better. I hope these PRs are not bothersome!

- Enforces present simple tense to make the documentation easier to read (e.g. `it is resolved once...` becomes `resolves once`)
- Enforces lowercasing at the start of the comment (`It is` was inconsistently capitalized)
- Enforces consistent pluralization (`as property and attributes` becomes `as properties and attributes`)
- Fixes a typo (`has been unmounted the document` becomes `has been unmounted from the document`)
- Corrects usage (`is executed` becomes `is successfully executed` because of https://github.com/atomicojs/base-element/blob/master/src/index.js#L84)